### PR TITLE
Remove the asterisk error

### DIFF
--- a/helpers/flatpak.ts
+++ b/helpers/flatpak.ts
@@ -53,7 +53,9 @@ export const upgrade = async (config: Config) => {
                 )}; ${mask}"`
             )
         } catch (error) {
-            console.error(error)
+            if(! error.includes("No current masked pattern matching *")) {
+                throw error
+            }
         }
     }
 }

--- a/helpers/flatpak.ts
+++ b/helpers/flatpak.ts
@@ -53,7 +53,7 @@ export const upgrade = async (config: Config) => {
                 )}; ${mask}"`
             )
         } catch (error) {
-            if(! error.includes("No current masked pattern matching *")) {
+            if (!error.includes("No current masked pattern matching *")) {
                 throw error
             }
         }

--- a/helpers/flatpak.ts
+++ b/helpers/flatpak.ts
@@ -53,9 +53,7 @@ export const upgrade = async (config: Config) => {
                 )}; ${mask}"`
             )
         } catch (error) {
-            if (!error.includes("No current masked pattern matching *")) {
-                throw error
-            }
+            if (!error.includes("No current masked pattern matching *")) throw error
         }
     }
 }


### PR DESCRIPTION
Stop the "No current masked pattern matching *" from being printed on first run